### PR TITLE
:bug: Make overwrite prompt python 2.7 compatible

### DIFF
--- a/export_app/adapters.py
+++ b/export_app/adapters.py
@@ -7,6 +7,12 @@ from django.template.loader import render_to_string
 from export_app import settings
 
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
+
 # from http://stackoverflow.com/questions/3203286/how-to-create-a-read-only-class-property-in-python#3203659
 class classproperty(object):
 


### PR DESCRIPTION
Overwrite prompt fails in Python 2.7 as the semantics of input has changed in Python 3.