### PR TITLE
don't require pandoc to install pypandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,13 @@ try:
     import pypandoc
 
     README = pypandoc.convert_file('README.md', 'rst')
+except ImportError:
+    with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+    README = readme.read()
 except OSError:
     # pandoc is not installed, fallback to using raw contents
     README = open('README.md').read()
+
 
 
 # allow setup.py to be run from any path

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
     README = pypandoc.convert_file('README.md', 'rst')
 except ImportError:
     with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
-    README = readme.read()
+        README = readme.read()
 except OSError:
     # pandoc is not installed, fallback to using raw contents
     README = open('README.md').read()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ try:
 
     README = pypandoc.convert_file('README.md', 'rst')
 except OSError:
+    # pandoc is not installed, fallback to using raw contents
     README= open('README.md').read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,8 @@ try:
     import pypandoc
 
     README = pypandoc.convert_file('README.md', 'rst')
-except ImportError:
-    with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
-        README = readme.read()
+except OSError:
+    README= open('README.md').read()
 
 
 # allow setup.py to be run from any path

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
     README = pypandoc.convert_file('README.md', 'rst')
 except OSError:
     # pandoc is not installed, fallback to using raw contents
-    README= open('README.md').read()
+    README = open('README.md').read()
 
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
This changes closes #25 by allowing for pypandoc to install
without pandoc being present on the system.  This allows for
the library to be installed but for clients to handle the
fact that pandoc is not installed in their applications at
runtime.

If pandoc is not present during installation, the warning
from pypandoc is still printed informing users how pandoc
can be installed.