### PR TITLE
Allow __all__ keyword for field definition with non factory serializer

### DIFF
--- a/drf_auto_endpoint/decorators.py
+++ b/drf_auto_endpoint/decorators.py
@@ -81,16 +81,15 @@ def wizard(target_model, serializer=None, icon_class=None, btn_class=None, text=
     needs = []
     fields = []
     Adapter = import_string(settings.METADATA_ADAPTER)
-    for field in serializer.Meta.fields:
-        field_instance = serializer_instance.fields[field]
-        if isinstance(field_instance, PrimaryKeyRelatedField):
-            model = field_instance.queryset.model
+    for field_name, field in serializer_instance.fields.items():
+        if isinstance(field, PrimaryKeyRelatedField):
+            model = field.queryset.model
             needs.append({
                 'app': model._meta.app_label,
                 'singular': model._meta.model_name.lower(),
                 'plural': inflector.pluralize(model._meta.model_name.lower()),
             })
-        fields.append(Adapter.adapt_field(get_field_dict(field, serializer)))
+        fields.append(Adapter.adapt_field(get_field_dict(field_name, serializer)))
     kwargs['params']['needs'] = needs
     kwargs['params']['fields'] = fields
     kwargs['languages'] = get_languages()

--- a/drf_auto_endpoint/endpoints.py
+++ b/drf_auto_endpoint/endpoints.py
@@ -88,7 +88,7 @@ class EndpointMetaClass(type):
                             value.action_kwargs['params'] = value.action_kwargs.get('params', {})
                             value.action_kwargs['params']['fieldsets'] = [
                                 {'name': field}
-                                for field in value.serializer.Meta.fields
+                                for field in value.serializer().fields.keys()
                             ]
 
         if new_class.fieldsets is None and new_class.model is not None:
@@ -172,7 +172,7 @@ class BaseEndpoint(object):
 
         if self.fields is None:
             if self.serializer is not None:
-                return self.serializer.Meta.fields
+                return self.serializer().fields.keys()
 
             self.fields = tuple([f for f in get_all_field_names(self.model)
                                  if f not in self.default_language_field_names and

--- a/sample/tests/data.py
+++ b/sample/tests/data.py
@@ -10,6 +10,13 @@ class DummyProductSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'category')
 
 
+class AllFieldDummyProductSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Product
+        fields = '__all__'
+
+
 class DummyProductViewSet(viewsets.ModelViewSet):
 
     serializer_class = DummyProductSerializer

--- a/sample/tests/test_unit.py
+++ b/sample/tests/test_unit.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from ..models import Product, Category, PRODUCT_TYPES
 
-from .data import DummyProductSerializer, DummyProductViewSet, DummyProductSerializerWithField
+from .data import AllFieldDummyProductSerializer, DummyProductSerializer, DummyProductViewSet, DummyProductSerializerWithField
 
 from drf_auto_endpoint.endpoints import Endpoint
 from drf_auto_endpoint.router import router
@@ -106,6 +106,9 @@ class EndpointTestCase(TestCase):
 
         self.assertEqual(endpoint.get_serializer(), DummyProductSerializer)
 
+        endpoint = Endpoint(model=Product, serializer=AllFieldDummyProductSerializer)
+        self.assertEqual(len(endpoint.get_fields_for_serializer()), len(self.fields))
+
     def test_viewset_factory(self):
         viewset = self.endpoint.get_viewset()
         self.assertEqual(viewset.serializer_class, self.endpoint.get_serializer())
@@ -155,7 +158,7 @@ class EndpointTestCase(TestCase):
 
         serializer = endpoint.get_serializer()
         self.assertEqual(serializer.Meta.model, Product)
-        self.assertEqual(len(serializer.Meta.fields), len(self.endpoint.get_fields_for_serializer()))
+        self.assertEqual(len(serializer().fields.items()), len(self.endpoint.get_fields_for_serializer()))
 
         viewset = endpoint.get_viewset()
 


### PR DESCRIPTION
Couldn't find any example with wizard usage, but the changes shouldn't break it.
I minimized the changes there but I think the usage of serializer class vs instance should be normalized. 