### PR TITLE
Allow AutoMetadata subclasses to provide their own field metadata

### DIFF
--- a/drf_auto_endpoint/metadata.py
+++ b/drf_auto_endpoint/metadata.py
@@ -38,6 +38,9 @@ class AutoMetadataMixin(object):
         metadata.update(adapter.render_root(rv))
         return metadata
 
+    def get_field_dict(self, *args, **kwargs):
+        return get_field_dict(*args, **kwargs)
+
     def determine_metadata(self, request, view):
 
         try:
@@ -80,7 +83,7 @@ class AutoMetadataMixin(object):
                 if type_ is None:
                     raise NotImplementedError()
 
-                field_metadata = get_field_dict(field, serializer)
+                field_metadata = self.get_field_dict(field, serializer)
 
                 fields_metadata.append(field_metadata)
 


### PR DESCRIPTION
I would like to make use of the great implementation provided by `AutoMetadata` but also add some additional field metadata. I don't currently see an easy way to do this.

After this change, people will be able to subclass `AutoMetadata` and provide their own implementations of `get_field_dict` or (more likely) extend the value return by the super's implementation.