### PR TITLE
There may be some bugs

### DIFF
--- a/drf_auto_endpoint/metadata.py
+++ b/drf_auto_endpoint/metadata.py
@@ -64,6 +64,8 @@ class AutoMetadataMixin(object):
         endpoint = None
         if hasattr(view, 'endpoint'):
             endpoint = view.endpoint
+        elif hasattr(view, 'endpoint_class'):
+            endpoint = view.endpoint_class(viewset=view)
         else:
             if hasattr(serializer.Meta, 'model'):
                 from .endpoints import Endpoint
@@ -87,20 +89,20 @@ class AutoMetadataMixin(object):
 
                 fields_metadata.append(field_metadata)
 
-                for meta_info in adapter.metadata_info:
-                    if meta_info.attr == 'fields':
-                        metadata['fields'] = fields_metadata,
-                    elif meta_info.attr == 'fieldsets':
-                        metadata['fieldsets'] = [{
-                            'title': None,
-                            'fields': [
-                                {'key': field}
-                                for field in serializer_instance.fields.keys()
-                                if field != 'id' and field != '__str__'
-                            ]
-                        }]
-                    else:
-                        metadata[meta_info.attr] = meta_info.default
+            for meta_info in adapter.metadata_info:
+                if meta_info.attr == 'fields':
+                    metadata['fields'] = fields_metadata
+                elif meta_info.attr == 'fieldsets':
+                    metadata['fieldsets'] = [{
+                        'title': None,
+                        'fields': [
+                            {'key': field}
+                            for field in serializer_instance.fields.keys()
+                            if field != 'id' and field != '__str__'
+                        ]
+                    }]
+                else:
+                    metadata[meta_info.attr] = meta_info.default
         else:
             for meta_info in adapter.metadata_info:
                 if meta_info.attr_type == GETTER:

--- a/drf_auto_endpoint/metadata.py
+++ b/drf_auto_endpoint/metadata.py
@@ -64,12 +64,13 @@ class AutoMetadataMixin(object):
         endpoint = None
         if hasattr(view, 'endpoint'):
             endpoint = view.endpoint
-        elif hasattr(view, 'endpoint_class'):
-            endpoint = view.endpoint_class(viewset=view)
         else:
             if hasattr(serializer.Meta, 'model'):
-                from .endpoints import Endpoint
-                endpoint = Endpoint(serializer.Meta.model, viewset=view)
+                if hasattr(view, 'endpoint_class'):
+                    endpoint = view.endpoint_class(viewset=view)
+                else:
+                    from .endpoints import Endpoint
+                    endpoint = Endpoint(serializer.Meta.model, viewset=view)
 
         adapter = import_string(settings.METADATA_ADAPTER)()
         if endpoint is None:


### PR DESCRIPTION
fix some bugs
line:92 metadata['fields'] = fields_metadata,
The last comma is superfluous. Option operation will returns two-tier array
line:90 for meta_info in adapter.metadata_info:
It shouldn't be indented here

add line:72