### PR TITLE
🗑 import abstract base classes from collections.abc

### DIFF
--- a/drf_auto_endpoint/adapters.py
+++ b/drf_auto_endpoint/adapters.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
-from collections import namedtuple, defaultdict, Mapping
+from collections import namedtuple, defaultdict
+from collections.abc import Mapping
 
 
 PROPERTY = 1

--- a/drf_auto_endpoint/endpoints.py
+++ b/drf_auto_endpoint/endpoints.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 import json
 import os
 


### PR DESCRIPTION
This solves the deprecation warnings raised by importing ABCs directly from 'collections': 

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' 
is deprecated since Python 3.3, and in 3.10 it will stop working
```

