### PR TITLE
fix: Unable to install drf-schema-adapter with setuptools>67

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     ],
     install_requires=[
         'Django>=2.0',
-        'djangorestframework>=3.8<4.0',
+        'djangorestframework>=3.8,<4.0',
         'django-filter>=0.13.0',
         'Inflector>=2.0.11',
     ]


### PR DESCRIPTION
ref: https://github.com/rconvent/drf-schema-adapter/commit/68ec2e103bb7b6f7eb8fa903d7c5285c76689ae3

Just like https://github.com/drf-forms/drf-schema-adapter/issues/75 fix at `2.x` branch